### PR TITLE
Upgrade discord.js version to 14.8.0 to fix a known bug

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -38,7 +38,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/oceanroleplay/discord.ts/blob/main/.github/CODE_OF_CONDUCT.md)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/barthofu/tscord/blob/main/.github/CODE_OF_CONDUCT.md)
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "discord-api-types": "~0.37.29",
     "discord-logs": "~2.2.1",
     "discord-oauth2": "~2.11.0",
-    "discord.js": "~14.7.1",
+    "discord.js": "~14.8.0",
     "discordx": "~11.5.2",
     "dotenv": "~16.0.3",
     "express": "^4.18.2",


### PR DESCRIPTION
This bug occurs when initiating interactions:

https://stackoverflow.com/questions/75892478/discord-js-v14-7-1-typeerror-channel-istextbased-is-not-a-function

**Please describe the changes this PR makes and why it should be merged:**