### PR TITLE
fix: update interaction type to STRING_SELECT_MENU_INTERACTION to resolve DiscordAPIError

### DIFF
--- a/src/configs/logs.ts
+++ b/src/configs/logs.ts
@@ -22,6 +22,7 @@ export const logsConfig: LogsConfigType = {
 		exclude: [
 			'BUTTON_INTERACTION',
 			'SELECT_MENU_INTERACTION',
+			'STRING_SELECT_MENU_INTERACTION',
 		],
 	},
 

--- a/src/services/Logger.ts
+++ b/src/services/Logger.ts
@@ -42,6 +42,7 @@ export class Logger {
 		CONTEXT_MENU_INTERACTION: 'Context menu',
 		BUTTON_INTERACTION: 'Button',
 		SELECT_MENU_INTERACTION: 'Select menu',
+		STRING_SELECT_MENU_INTERACTION: 'Select menu',
 		MODAL_SUBMIT_INTERACTION: 'Modal submit',
 	}
 

--- a/src/utils/types/interactions.d.ts
+++ b/src/utils/types/interactions.d.ts
@@ -6,7 +6,7 @@ type OnTheFlyInteractions = import('discord.js').ButtonInteraction | import('dis
 
 type AllInteractions = EmittedInteractions | OnTheFlyInteractions
 
-type InteractionsConstants = 'CHAT_INPUT_COMMAND_INTERACTION' | 'SIMPLE_COMMAND_MESSAGE' | 'CONTEXT_MENU_INTERACTION' | 'BUTTON_INTERACTION' | 'SELECT_MENU_INTERACTION' | 'MODAL_SUBMIT_INTERACTION'
+type InteractionsConstants = 'CHAT_INPUT_COMMAND_INTERACTION' | 'SIMPLE_COMMAND_MESSAGE' | 'CONTEXT_MENU_INTERACTION' | 'BUTTON_INTERACTION' | 'SELECT_MENU_INTERACTION' | 'STRING_SELECT_MENU_INTERACTION' | 'MODAL_SUBMIT_INTERACTION'
 
 type CommandCategory = import('discordx').DApplicationCommand & import('@discordx/utilities').ICategory
 


### PR DESCRIPTION
### Summary
This pull request updates the interaction type for menu interactions to `STRING_SELECT_MENU_INTERACTION` to align the Discord API.

### Changes Made
- **logs.ts**: Updated the interaction exclusion list to use `STRING_SELECT_MENU_INTERACTION` as well as `SELECT_MENU_INTERACTION`.
- **Logger.ts**: Added `STRING_SELECT_MENU_INTERACTION` to the list of recognized interaction types.
- **interactions.d.ts**: Updated `InteractionsConstants` to include `STRING_SELECT_MENU_INTERACTION`.

### Reason for Changes
I encountered an issue with menu interactions returning `STRING_SELECT_MENU_INTERACTION` instead of `SELECT_MENU_INTERACTION`. This update ensures that the correct interaction type is used.

```
info [08/08/2024 - 03:46:05] (CHAT_INPUT_COMMAND_INTERACTION) "help" in channel #🤖commands in guild okRick's server by okrick#0
info [08/08/2024 - 03:46:10] (STRING_SELECT_MENU_INTERACTION) "help-category-selector" in channel #🤖commands in guild okRick's server by okrick#0
error [08/08/2024 - 03:46:10] DiscordAPIError[50035]: Invalid Form Body
embeds[0].fields[0].value[BASE_TYPE_REQUIRED]: This field is required
```